### PR TITLE
Fix utf8 -> latin1

### DIFF
--- a/reedsolo.py
+++ b/reedsolo.py
@@ -93,7 +93,7 @@ try:
     bytearray
 except NameError:
     from array import array
-    def bytearray(obj = 0, encoding = "latin-1"):
+    def bytearray(obj = 0, encoding = "latin-1"): # always use Latin-1 and not UTF8 because Latin-1 maps the first 256 characters to their bytevalue equivalents. UTF8 may mangle your data (particularly at vale 128)
         if isinstance(obj, str):
             obj = [ord(ch) for ch in obj.encode("latin-1")]
         elif isinstance(obj, int):

--- a/tests/test_creedsolo.py
+++ b/tests/test_creedsolo.py
@@ -28,14 +28,14 @@ except NameError:
 class cTestReedSolomon(unittest.TestCase):
     def test_simple(self):
         rs = RSCodec(10)
-        msg = bytearray("hello world " * 10, "utf8")
+        msg = bytearray("hello world " * 10, "latin1")
         enc = rs.encode(msg)
         dec = rs.decode(enc)
         self.assertEqual(dec, msg)
     
     def test_correction(self):
         rs = RSCodec(10)
-        msg = bytearray("hello world " * 10, "utf8")
+        msg = bytearray("hello world " * 10, "latin1")
         enc = rs.encode(msg)
         self.assertEqual(rs.decode(enc), msg)
         for i in [27, -3, -9, 7, 0]:
@@ -46,7 +46,7 @@ class cTestReedSolomon(unittest.TestCase):
     
     def test_long(self):
         rs = RSCodec(10)
-        msg = bytearray("a" * 10000, "utf8")
+        msg = bytearray("a" * 10000, "latin1")
         enc = rs.encode(msg)
         dec = rs.decode(enc)
         self.assertEqual(dec, msg)
@@ -203,7 +203,7 @@ class cTestRSCodecUniversalCrossValidation(unittest.TestCase):
 
         debugg = False # if one or more tests don't pass, you can enable this flag to True to get verbose output to debug
 
-        orig_mes = bytearray("hello world", "utf8")
+        orig_mes = bytearray("hello world", "latin1")
         n = len(orig_mes)*2
         k = len(orig_mes)
         nsym = n-k

--- a/tests/test_reedsolo.py
+++ b/tests/test_reedsolo.py
@@ -28,14 +28,14 @@ except NameError:
 class TestReedSolomon(unittest.TestCase):
     def test_simple(self):
         rs = RSCodec(10)
-        msg = bytearray("hello world " * 10, "utf8")
+        msg = bytearray("hello world " * 10, "latin1")
         enc = rs.encode(msg)
         dec = rs.decode(enc)
         self.assertEqual(dec, msg)
     
     def test_correction(self):
         rs = RSCodec(10)
-        msg = bytearray("hello world " * 10, "utf8")
+        msg = bytearray("hello world " * 10, "latin1")
         enc = rs.encode(msg)
         self.assertEqual(rs.decode(enc), msg)
         for i in [27, -3, -9, 7, 0]:
@@ -46,7 +46,7 @@ class TestReedSolomon(unittest.TestCase):
     
     def test_long(self):
         rs = RSCodec(10)
-        msg = bytearray("a" * 10000, "utf8")
+        msg = bytearray("a" * 10000, "latin1")
         enc = rs.encode(msg)
         dec = rs.decode(enc)
         self.assertEqual(dec, msg)
@@ -203,7 +203,7 @@ class TestRSCodecUniversalCrossValidation(unittest.TestCase):
 
         debugg = False # if one or more tests don't pass, you can enable this flag to True to get verbose output to debug
 
-        orig_mes = bytearray("hello world", "utf8")
+        orig_mes = bytearray("hello world", "latin1")
         n = len(orig_mes)*2
         k = len(orig_mes)
         nsym = n-k


### PR DESCRIPTION
Fix a potential issue in the future in the test cases I have added (messages were encoded in UTF8 instead of Latin1). The library itself didn't contain any issue, it's only in the unit test.