### PR TITLE
setup.py: Fix installation via 'pip' if no C compiler is available

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Installation
 
     When installing from source using ``python setup.py install``, the setup.py will try to build the Cython optimized module ``creedsolo.pyx`` if Cython is installed. You can override this behavior by typing: ``python setup.py install --nocython``.
 
-    A pre-transpiled ``creedsolo.c`` is also available, and can be compiled without Cython by typing: ``python setup.py install --compile``.
+    A pre-transpiled ``creedsolo.c`` is also available, and can be compiled without Cython by typing: ``python setup.py install --native-compile``.
 
     The package on ``pip`` includes a pre-compiled ``creedsolo.pyd`` module for Windows 10 x64.
 
@@ -289,7 +289,7 @@ The ``RSCodec`` class will automatically apply chunking, by splitting longer mes
 encode/decode them separately; it shouldn't make a difference from an API perspective (ie, from your POV).
 
 
-To use the Cython implementation, you need to ``pip install cython`` and a C++ compiler (Microsoft Visual C++ 14.0 for Windows and Python 3.7). Then you can simply cd to the root of the folder where creedsolo.pyx is, and type ``python setup.py build_ext --inplace``. Alternatively, you can generate just the C++ code by typing `cython -3 creedsolo.pyx`. When building a distributable egg or installing the module from source, the Cython module will be automatically transpiled and compiled if both Cython and a C compiler are installed. This behavior can be modified using the ``--nocython`` and ``--compile`` arguments for ``setup.py``.
+To use the Cython implementation, you need to ``pip install cython`` and a C++ compiler (Microsoft Visual C++ 14.0 for Windows and Python 3.7). Then you can simply cd to the root of the folder where creedsolo.pyx is, and type ``python setup.py build_ext --inplace``. Alternatively, you can generate just the C++ code by typing `cython -3 creedsolo.pyx`. When building a distributable egg or installing the module from source, the Cython module will be automatically transpiled and compiled if both Cython and a C compiler are installed. This behavior can be modified using the ``--nocython`` and ``--native-compile`` arguments for ``setup.py``.
 
 Authors
 -------

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ try:
     extensions = cythonize([ Extension('creedsolo', ['creedsolo.pyx']) ])
 except ImportError:
     # Else Cython is not installed (or user explicitly wanted to skip)
-    if '--compile' in sys.argv:
+    if '--native-compile' in sys.argv:
         # Compile pyd from pre-transpiled creedsolo.c
         print("Cython is not installed, but the creedsolo module will be built from the pre-transpiled creedsolo.c file using the locally installed C compiler")
-        sys.argv.remove('--compile')
+        sys.argv.remove('--native-compile')
         extensions = [ Extension('creedsolo', ['creedsolo.c']) ]
     else:
         # Else run in pure python mode (no compilation)


### PR DESCRIPTION
Hi again!

This is a follow-up to the amended version of #21 that was merged as v1.5.3.

Screenshot of `pip install reedsolo` on Windows Python 3.8:
![Screenshot from 2020-05-19 10-14-51](https://user-images.githubusercontent.com/205573/82271641-b7cfbb80-99bb-11ea-98dc-a3eb2eb550d5.png)

(With no native compiler installed.) Description of what's happening included below and in commit message. This only seems to happen on Python 3.x not 2.7, but it might be the pip version not the Python version that makes the difference.

I haven't bumped the package version in this PR, but is it a problem to please make a 1.5.4 release on pypi with this fix soon?

Please let me know if you want me to make any changes at all. Thanks for all your work maintaining this package. :)

---

Fix renames the package-specific --compile option to --native-compile

Reason: setuptools also has a --compile option (recognized by both pip and
setup.py, although setup.py usage doesn't seem to be documented anywhere.)
However this --compile option controls compiling Python bytecode, not native
code.

--compile is the default, but recent versions of pip will pass this option
explicitly to setup.py:
https://github.com/pypa/pip/blob/9cbe8fbdd0a1bd1bd4e483c9c0a556e9910ef8bb/src/pip/_internal/utils/setuptools_build.py#L171

This would cause native compilation to trigger even when no native compiler is installed.

---
