### PR TITLE
Force cythonize of *.pyx file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ try:
     # If Cython is installed, transpile the optimized Cython module to C and compile as a .pyd to be distributed
     from Cython.Build import cythonize
     print("Cython is installed, building creedsolo module")
-    extensions = cythonize([ Extension('creedsolo', ['creedsolo.pyx']) ])
+    extensions = cythonize([ Extension('creedsolo', ['creedsolo.pyx']) ], force=True)
 except ImportError:
     # Else Cython is not installed (or user explicitly wanted to skip)
     if '--native-compile' in sys.argv:


### PR DESCRIPTION
Close #36 

It seems like `cythonize` of your `*.pyx` does not do anything if a `*.c` file. By using `force=True` it uses the `*.pyx` and also fixes the issues on Python 3.10. I also applied this fix as a patch to the [conda-forge-recipe](https://github.com/conda-forge/reedsolo-feedstock) in https://github.com/conda-forge/reedsolo-feedstock/pull/6 and will remove it once you released a new version.