### PR TITLE
include tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 include README.rst
 include changelog.txt
 include *.pyx # include the cython implementation sourcecode in the wheel, so that the user can compile later
+recursive-include tests *.py


### PR DESCRIPTION
Include tests in source distribution archives to make them a suitable source for packagers in Linux distributions and Conda-forge who run tests as part of the packaging process.